### PR TITLE
Replace PyInquirer with its defacto successor inquirer

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.9']
+        python-version: ['3.7', '3.10']
 
     name: Python ${{ matrix.python-version }} build
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-requests==2.26.0
 geojson==2.5.0
+inquirer==2.9.1
+requests==2.27.1
+setuptools==59.3.0
 thefuzz==0.19.0
-PyInquirer==1.0.3
 python_dateutil==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -35,10 +35,10 @@ License :: OSI Approved :: MIT License
 Operating System :: OS Independent
 Programming Language :: Python
 Programming Language :: Python :: 3
-Programming Language :: Python :: 3.6
 Programming Language :: Python :: 3.7
 Programming Language :: Python :: 3.8
 Programming Language :: Python :: 3.9
+Programming Language :: Python :: 3.10
 Programming Language :: Python :: Implementation :: CPython
 Programming Language :: Python :: Implementation :: PyPy
 Topic :: Scientific/Engineering
@@ -58,7 +58,7 @@ setup(
     packages=find_packages(exclude=["docs", "tests*"]),
     install_requires=install_requires,
     test_suite="setup.test_suite",
-    python_requires=">=3.6,<3.10",
+    python_requires=">=3.7,<=3.10",
     classifiers=classifiers.splitlines(),
     entry_points={
         "console_scripts": [

--- a/stapy/cli/cli.py
+++ b/stapy/cli/cli.py
@@ -1,4 +1,4 @@
-from PyInquirer import prompt
+from inquirer import prompt
 import logging
 
 from stapy.sta.entity import Entity
@@ -12,7 +12,7 @@ logger = logging.getLogger("root")
 
 class CLI(object):
     """
-    This class contains the interactive TUI build with PyInquirer
+    This class contains the interactive TUI build with inquirer
     """
 
     def __init__(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -64,7 +64,7 @@ class TestSTAMethods(unittest.TestCase):
         self.assertEqual(cap_first("Test"), "Test")
         self.assertEqual(cap_first(0), "")
 
-    @mock.patch("PyInquirer.prompt")
+    @mock.patch("inquirer.prompt")
     def test_cprompt(self, mocked_prompt):
         mocked_prompt.side_effect = {}
         with self.assertRaises(SystemExit):


### PR DESCRIPTION
Replacing PyInquirer with its defacto successor inquirer since the first mentioned is not maintained anymore